### PR TITLE
feat(transcribe): add allow_feedback parameter to control ASR cloud logging

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -9,11 +9,14 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/Mininglamp-OSS/octo-speech/internal/asrlog"
 	"github.com/Mininglamp-OSS/octo-speech/internal/config"
 	"github.com/Mininglamp-OSS/octo-speech/internal/service"
 	"github.com/Mininglamp-OSS/octo-speech/internal/store"
@@ -931,6 +934,245 @@ func TestClassifyTranscribeError(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := classifyTranscribeError(tt.err); got != tt.want {
 				t.Errorf("classifyTranscribeError() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTranscribeHandler_AllowFeedback_InvalidValue(t *testing.T) {
+	cfg := &config.Config{
+		MaxFileSize:            3145728,
+		EmotionEmoji:           true,
+		AllowFeedbackLog:       true,
+		MaxContextTextLength:   5000,
+		MaxChatContextLength:   20000,
+		MaxVoiceContextLength:  10000,
+		MaxMemberContextLength: 5000,
+	}
+
+	h := NewTranscribeHandler(nil, cfg, nil, nil)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.POST("/v1/speech/transcribe", h.Handle)
+
+	invalidValues := []string{"maybe", "yes", "no", "2", " "}
+	for _, val := range invalidValues {
+		t.Run("allow_feedback="+val, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer := multipart.NewWriter(&buf)
+			part, _ := writer.CreateFormFile("audio", "test.wav")
+			part.Write([]byte("fake audio"))
+			writer.WriteField("allow_feedback", val)
+			writer.Close()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/speech/transcribe", &buf)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("expected 400 for allow_feedback=%q, got %d: %s", val, w.Code, w.Body.String())
+			}
+
+			var resp map[string]interface{}
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["msg"] != "invalid allow_feedback value, expected: true or false" {
+				t.Errorf("unexpected msg: %v", resp["msg"])
+			}
+		})
+	}
+}
+
+func TestTranscribeHandler_AllowFeedback_ValidValues(t *testing.T) {
+	cfg := &config.Config{
+		MaxFileSize:            3145728,
+		EmotionEmoji:           true,
+		AllowFeedbackLog:       true,
+		MaxContextTextLength:   5000,
+		MaxChatContextLength:   20000,
+		MaxVoiceContextLength:  10000,
+		MaxMemberContextLength: 5000,
+	}
+
+	h := NewTranscribeHandler(nil, cfg, nil, nil)
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.POST("/v1/speech/transcribe", h.Handle)
+
+	validValues := []string{"true", "false", "1", "0", "t", "f", "TRUE", "FALSE"}
+	for _, val := range validValues {
+		t.Run("allow_feedback="+val, func(t *testing.T) {
+			var buf bytes.Buffer
+			writer := multipart.NewWriter(&buf)
+			part, _ := writer.CreateFormFile("audio", "test.wav")
+			part.Write([]byte("fake audio"))
+			writer.WriteField("allow_feedback", val)
+			writer.Close()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/speech/transcribe", &buf)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			r.ServeHTTP(w, req)
+
+			if w.Code == http.StatusBadRequest {
+				var resp map[string]interface{}
+				json.Unmarshal(w.Body.Bytes(), &resp)
+				if resp["msg"] == "invalid allow_feedback value, expected: true or false" {
+					t.Errorf("valid allow_feedback=%q was rejected", val)
+				}
+			}
+		})
+	}
+}
+
+func TestTranscribeHandler_AllowFeedback_NotProvided(t *testing.T) {
+	cfg := &config.Config{
+		MaxFileSize:            3145728,
+		EmotionEmoji:           true,
+		AllowFeedbackLog:       true,
+		MaxContextTextLength:   5000,
+		MaxChatContextLength:   20000,
+		MaxVoiceContextLength:  10000,
+		MaxMemberContextLength: 5000,
+	}
+
+	h := NewTranscribeHandler(nil, cfg, nil, nil)
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.POST("/v1/speech/transcribe", h.Handle)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("audio", "test.wav")
+	part.Write([]byte("fake audio"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/transcribe", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusBadRequest {
+		var resp map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &resp)
+		if resp["msg"] == "invalid allow_feedback value, expected: true or false" {
+			t.Error("missing allow_feedback should not cause 400")
+		}
+	}
+}
+
+func TestTranscribeHandler_AllowFeedback_LoggingBehavior(t *testing.T) {
+	service.ResetPromptsToDefaults()
+
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"choices": []map[string]interface{}{
+				{"message": map[string]string{"content": "transcribed text"}},
+			},
+		})
+	}))
+	defer backend.Close()
+
+	tests := []struct {
+		name             string
+		allowFeedbackLog bool
+		paramValue       string
+		expectLogged     bool
+	}{
+		{"config=true, param=true", true, "true", true},
+		{"config=true, param=false", true, "false", false},
+		{"config=false, param=true", false, "true", true},
+		{"config=false, param=false", false, "false", false},
+		{"config=true, no param", true, "", true},
+		{"config=false, no param", false, "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logDir := t.TempDir()
+			asrLogger := asrlog.NewLogger(logDir, 256, "test-pod", nil)
+			if asrLogger == nil {
+				t.Fatal("failed to create asr logger")
+			}
+			defer asrLogger.Close()
+
+			cfg := &config.Config{
+				MaxFileSize:            3145728,
+				EmotionEmoji:           true,
+				AllowFeedbackLog:       tt.allowFeedbackLog,
+				MaxContextTextLength:   5000,
+				MaxChatContextLength:   20000,
+				MaxVoiceContextLength:  10000,
+				MaxMemberContextLength: 5000,
+				Engine:                 config.EngineGemini,
+				Models:                 []string{"test-model"},
+				LiteLLMUrl:             backend.URL,
+				LiteLLMKey:             "test-key",
+				Timeout:                10,
+				TotalTimeout:           15,
+			}
+
+			svc := service.NewTranscribeService(cfg)
+			h := NewTranscribeHandler(svc, cfg, asrLogger, nil)
+
+			r := gin.New()
+			r.Use(func(c *gin.Context) {
+				c.Set("app_id", "test-app")
+				c.Next()
+			})
+			r.POST("/v1/speech/transcribe", h.Handle)
+
+			var buf bytes.Buffer
+			writer := multipart.NewWriter(&buf)
+			part, _ := writer.CreateFormFile("audio", "test.wav")
+			part.Write([]byte("fake audio"))
+			if tt.paramValue != "" {
+				writer.WriteField("allow_feedback", tt.paramValue)
+			}
+			writer.Close()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/speech/transcribe", &buf)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			r.ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			asrLogger.Close()
+
+			hasLogFiles := false
+			filepath.WalkDir(logDir, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if !d.IsDir() && strings.HasSuffix(d.Name(), ".json") {
+					hasLogFiles = true
+				}
+				return nil
+			})
+
+			if tt.expectLogged && !hasLogFiles {
+				t.Error("expected log files to be written, but none found")
+			}
+			if !tt.expectLogged && hasLogFiles {
+				t.Error("expected no log files, but some were found")
 			}
 		})
 	}

--- a/internal/api/transcribe.go
+++ b/internal/api/transcribe.go
@@ -99,6 +99,7 @@ func (h *TranscribeHandler) Handle(c *gin.Context) {
 	engineParam := c.PostForm("engine")
 	modelParam := c.PostForm("model")
 	emotionParam := c.PostForm("emotion_emoji")
+	allowFeedbackParam := c.PostForm("allow_feedback")
 
 	if channelType != "" && channelType != "dm" && channelType != "group" && channelType != "thread" && channelType != "1" && channelType != "2" && channelType != "5" {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -180,6 +181,20 @@ func (h *TranscribeHandler) Handle(c *gin.Context) {
 		}
 	}
 
+	shouldLog := h.cfg.AllowFeedbackLog
+	if allowFeedbackParam != "" {
+		b, err := strconv.ParseBool(allowFeedbackParam)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"status":     http.StatusBadRequest,
+				"msg":        "invalid allow_feedback value, expected: true or false",
+				"request_id": requestID,
+			})
+			return
+		}
+		shouldLog = b
+	}
+
 	result, err := h.svc.Transcribe(audioData, mimeType, contextText, vocabRef, opts)
 
 	duration := time.Since(startTime)
@@ -189,7 +204,7 @@ func (h *TranscribeHandler) Handle(c *gin.Context) {
 		engine = opts.Engine
 	}
 
-	if h.asrLogger != nil {
+	if h.asrLogger != nil && shouldLog {
 		entry := asrlog.ASREntry{
 			RequestID:      requestID,
 			Timestamp:      startTime.UTC().Format(time.RFC3339Nano),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -78,8 +78,9 @@ type Config struct {
 	ASRLogBufferSize   int
 	ASRLogRetentionDays int
 
-	Hostname    string
-	FeedbackURL string
+	Hostname         string
+	FeedbackURL      string
+	AllowFeedbackLog bool
 
 	ReadTimeout  time.Duration
 	WriteTimeout time.Duration
@@ -121,6 +122,7 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 
 		ASRLogBufferSize:    defaultLogBufSize,
 		ASRLogRetentionDays: defaultRetention,
+		AllowFeedbackLog:    true,
 
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 60 * time.Second,
@@ -263,6 +265,12 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 	cfg.ASRLogDir = os.Getenv("ASR_LOG_DIR")
 
 	cfg.FeedbackURL = os.Getenv("VOICE_FEEDBACK_URL")
+
+	if v := os.Getenv("VOICE_ALLOW_FEEDBACK"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.AllowFeedbackLog = b
+		}
+	}
 
 	if v := os.Getenv("ASR_LOG_BUFFER_SIZE"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -61,6 +61,9 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	if len(cfg.Models) != 3 || cfg.Models[0] != "gemini-3.1-pro-preview" {
 		t.Errorf("unexpected default models: %v", cfg.Models)
 	}
+	if !cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog true by default")
+	}
 }
 
 func TestLoadFromEnv_CustomValues(t *testing.T) {
@@ -321,5 +324,75 @@ func TestEngineShort(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("EngineShort() for %s = %q, want %q", tt.engine, got, tt.want)
 		}
+	}
+}
+
+func TestLoadFromEnv_AllowFeedbackLog_Default(t *testing.T) {
+	os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if !cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog true by default")
+	}
+}
+
+func TestLoadFromEnv_AllowFeedbackLog_SetFalse(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_ALLOW_FEEDBACK", "false")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog false when VOICE_ALLOW_FEEDBACK=false")
+	}
+}
+
+func TestLoadFromEnv_AllowFeedbackLog_SetTrue(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_ALLOW_FEEDBACK", "true")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if !cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog true when VOICE_ALLOW_FEEDBACK=true")
+	}
+}
+
+func TestLoadFromEnv_AllowFeedbackLog_InvalidIgnored(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_ALLOW_FEEDBACK", "yes")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if !cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog to remain true when VOICE_ALLOW_FEEDBACK has invalid value")
+	}
+}
+
+func TestLoadFromEnv_AllowFeedbackLog_Zero(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_ALLOW_FEEDBACK", "0")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog false when VOICE_ALLOW_FEEDBACK=0")
+	}
+}
+
+func TestLoadFromEnv_AllowFeedbackLog_One(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_ALLOW_FEEDBACK", "1")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if !cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog true when VOICE_ALLOW_FEEDBACK=1")
 	}
 }


### PR DESCRIPTION
## Summary

Add `allow_feedback` boolean parameter to `POST /v1/speech/transcribe` to control whether ASR logs are recorded.

Closes #7

## Changes

### `internal/config/config.go`
- Add `AllowFeedbackLog bool` field to `Config` struct
- Load from `VOICE_ALLOW_FEEDBACK` env var (default: `true`)

### `internal/api/transcribe.go`
- Parse `allow_feedback` form field after `emotion_emoji`
- Invalid values (e.g. `maybe`, `yes`) → 400 Bad Request
- Change `asrLogger.Enqueue` condition: `h.asrLogger != nil && shouldLog`

### Tests
- `config_test.go`: 7 new tests for env var handling
- `api_test.go`: 4 new test functions covering valid/invalid/priority/logging behavior

## Priority (three-level fallback)

```
Request param allow_feedback  >  Env VOICE_ALLOW_FEEDBACK  >  Default true
```

## Design Doc

See `docs/allow-feedback-design-v2.md` for full specification.

## Test Results

```
ok  github.com/Mininglamp-OSS/octo-speech/internal/api
ok  github.com/Mininglamp-OSS/octo-speech/internal/config
```

All existing + new tests pass.