### PR TITLE
feat(config): make maxUploadSize configurable via VOICE_MAX_UPLOAD_SIZE

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -292,8 +292,9 @@ func TestConfigHandler_FeedbackURL_Absent(t *testing.T) {
 
 func TestTranscribeHandler_MissingAudio(t *testing.T) {
 	cfg := &config.Config{
-		MaxFileSize:  3145728,
-		EmotionEmoji: true,
+		MaxUploadSize: 5 * 1024 * 1024,
+		MaxFileSize:   3145728,
+		EmotionEmoji:  true,
 	}
 
 	h := NewTranscribeHandler(nil, cfg, nil, nil)
@@ -317,6 +318,7 @@ func TestTranscribeHandler_MissingAudio(t *testing.T) {
 
 func TestTranscribeHandler_InvalidMode(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -353,6 +355,7 @@ func TestTranscribeHandler_InvalidMode(t *testing.T) {
 
 func TestTranscribeHandler_InvalidEngine(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -548,6 +551,7 @@ func TestVocabularyHandler_DeleteDefaultScope(t *testing.T) {
 
 func TestTranscribeHandler_EditOnlyWithoutContextText(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -590,6 +594,7 @@ func TestTranscribeHandler_EditOnlyWithoutContextText(t *testing.T) {
 
 func TestTranscribeHandler_InvalidChannelType(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -632,6 +637,7 @@ func TestTranscribeHandler_InvalidChannelType(t *testing.T) {
 
 func TestTranscribeHandler_ChannelTypeThread(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -725,6 +731,7 @@ func TestTranscribeHandler_ChannelTypeThread_SkipMentionFalse(t *testing.T) {
 			defer backend.Close()
 
 			cfg := &config.Config{
+				MaxUploadSize:          5 * 1024 * 1024,
 				MaxFileSize:            3145728,
 				EmotionEmoji:           true,
 				MaxContextTextLength:   5000,
@@ -788,6 +795,7 @@ func (e *mockNetError) Temporary() bool { return false }
 
 func TestTranscribeHandler_RequestBodyTooLarge(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -830,6 +838,7 @@ func TestTranscribeHandler_RequestBodyTooLarge(t *testing.T) {
 
 func TestTranscribeHandler_InvalidModel(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -875,6 +884,7 @@ func TestTranscribeHandler_InvalidModel(t *testing.T) {
 
 func TestTranscribeHandler_ValidModel(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		MaxContextTextLength:   5000,
@@ -941,6 +951,7 @@ func TestClassifyTranscribeError(t *testing.T) {
 
 func TestTranscribeHandler_AllowFeedback_InvalidValue(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		AllowFeedbackLog:       true,
@@ -989,6 +1000,7 @@ func TestTranscribeHandler_AllowFeedback_InvalidValue(t *testing.T) {
 
 func TestTranscribeHandler_AllowFeedback_ValidValues(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		AllowFeedbackLog:       true,
@@ -1036,6 +1048,7 @@ func TestTranscribeHandler_AllowFeedback_ValidValues(t *testing.T) {
 
 func TestTranscribeHandler_AllowFeedback_NotProvided(t *testing.T) {
 	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
 		MaxFileSize:            3145728,
 		EmotionEmoji:           true,
 		AllowFeedbackLog:       true,
@@ -1112,6 +1125,7 @@ func TestTranscribeHandler_AllowFeedback_LoggingBehavior(t *testing.T) {
 			defer asrLogger.Close()
 
 			cfg := &config.Config{
+				MaxUploadSize:          5 * 1024 * 1024,
 				MaxFileSize:            3145728,
 				EmotionEmoji:           true,
 				AllowFeedbackLog:       tt.allowFeedbackLog,
@@ -1175,5 +1189,85 @@ func TestTranscribeHandler_AllowFeedback_LoggingBehavior(t *testing.T) {
 				t.Error("expected no log files, but some were found")
 			}
 		})
+	}
+}
+
+func TestTranscribeHandler_RequestBodyWithinLimit(t *testing.T) {
+	cfg := &config.Config{
+		MaxUploadSize:          5 * 1024 * 1024,
+		MaxFileSize:            3 * 1024 * 1024,
+		EmotionEmoji:           true,
+		MaxContextTextLength:   5000,
+		MaxChatContextLength:   20000,
+		MaxVoiceContextLength:  10000,
+		MaxMemberContextLength: 5000,
+	}
+
+	h := NewTranscribeHandler(nil, cfg, nil, nil)
+
+	r := gin.New()
+	r.Use(gin.Recovery())
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.POST("/v1/speech/transcribe", h.Handle)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("audio", "test.wav")
+	part.Write(make([]byte, 100))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/transcribe", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusRequestEntityTooLarge {
+		t.Errorf("expected request within limit to not return 413, got %d", w.Code)
+	}
+}
+
+func TestTranscribeHandler_MaxUploadSize(t *testing.T) {
+	cfg := &config.Config{
+		MaxUploadSize:          1024,
+		MaxFileSize:            512,
+		EmotionEmoji:           true,
+		MaxContextTextLength:   5000,
+		MaxChatContextLength:   20000,
+		MaxVoiceContextLength:  10000,
+		MaxMemberContextLength: 5000,
+	}
+
+	h := NewTranscribeHandler(nil, cfg, nil, nil)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.POST("/v1/speech/transcribe", h.Handle)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("audio", "test.wav")
+	largeData := make([]byte, 2048)
+	part.Write(largeData)
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/transcribe", &buf)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Errorf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "request body too large" {
+		t.Errorf("unexpected msg: %v", resp["msg"])
 	}
 }

--- a/internal/api/transcribe.go
+++ b/internal/api/transcribe.go
@@ -45,8 +45,7 @@ func (h *TranscribeHandler) Handle(c *gin.Context) {
 		requestID = fmt.Sprintf("nolog_%d_%s", time.Now().UnixMilli(), hex.EncodeToString(b))
 	}
 
-	const maxUploadSize = 5 * 1024 * 1024
-	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxUploadSize)
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, h.cfg.MaxUploadSize)
 
 	file, header, err := c.Request.FormFile("audio")
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,14 +18,15 @@ const (
 )
 
 const (
-	defaultPort         = 8780
-	defaultTimeout      = 30
-	defaultTotalTimeout = 45
-	defaultMaxDuration  = 60
-	defaultMaxFileSize  = 3 * 1024 * 1024
-	defaultCacheTTL     = 60
-	defaultLogBufSize   = 256
-	defaultRetention    = 7
+	defaultMaxUploadSize = 5 * 1024 * 1024
+	defaultPort          = 8780
+	defaultTimeout       = 30
+	defaultTotalTimeout  = 45
+	defaultMaxDuration   = 60
+	defaultMaxFileSize   = 3 * 1024 * 1024
+	defaultCacheTTL      = 60
+	defaultLogBufSize    = 256
+	defaultRetention     = 7
 )
 
 const (
@@ -49,8 +50,13 @@ type Config struct {
 	Timeout      int
 	TotalTimeout int
 	Models       []string
-	MaxDuration  int
-	MaxFileSize  int64
+	MaxDuration int
+	// MaxUploadSize is the hard limit on the entire HTTP request body size (including
+	// multipart boundaries and headers). Requests exceeding this are rejected with 413.
+	// VOICE_MAX_FILE_SIZE must be smaller than this value, otherwise the file size
+	// check will never trigger (the request body will be truncated first).
+	MaxUploadSize int64
+	MaxFileSize   int64
 	Engine       string
 	GPTModels    []string
 	Language     string
@@ -104,6 +110,7 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 		TotalTimeout: defaultTotalTimeout,
 		Models:       models,
 		MaxDuration:  defaultMaxDuration,
+		MaxUploadSize: defaultMaxUploadSize,
 		MaxFileSize:  defaultMaxFileSize,
 		Engine:       EngineGemini,
 		GPTModels:    gptModels,
@@ -175,6 +182,12 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 	if v := os.Getenv("VOICE_MAX_FILE_SIZE"); v != "" {
 		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
 			cfg.MaxFileSize = n
+		}
+	}
+
+	if v := os.Getenv("VOICE_MAX_UPLOAD_SIZE"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			cfg.MaxUploadSize = n
 		}
 	}
 
@@ -306,6 +319,13 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 func (c *Config) Validate() error {
 	if c.DBDsn == "" {
 		return errors.New("SPEECH_DB_DSN is required")
+	}
+
+	if c.MaxUploadSize <= 0 {
+		return errors.New("VOICE_MAX_UPLOAD_SIZE must be positive")
+	}
+	if c.MaxFileSize >= c.MaxUploadSize {
+		return errors.New("VOICE_MAX_FILE_SIZE must be smaller than VOICE_MAX_UPLOAD_SIZE")
 	}
 
 	if c.Engine == EngineQwen {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -173,11 +173,13 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid gemini",
 			cfg: Config{
-				DBDsn:      "dsn",
-				LiteLLMUrl: "http://url",
-				LiteLLMKey: "key",
-				Engine:     EngineGemini,
-				Models:     []string{"m1"},
+				DBDsn:         "dsn",
+				LiteLLMUrl:    "http://url",
+				LiteLLMKey:    "key",
+				Engine:        EngineGemini,
+				Models:        []string{"m1"},
+				MaxUploadSize: 5 * 1024 * 1024,
+				MaxFileSize:   3 * 1024 * 1024,
 			},
 		},
 		{
@@ -203,21 +205,25 @@ func TestValidate(t *testing.T) {
 		{
 			name: "valid gpt",
 			cfg: Config{
-				DBDsn:      "dsn",
-				LiteLLMUrl: "http://url",
-				LiteLLMKey: "key",
-				Engine:     EngineGPT,
-				GPTModels:  []string{"gpt4"},
+				DBDsn:         "dsn",
+				LiteLLMUrl:    "http://url",
+				LiteLLMKey:    "key",
+				Engine:        EngineGPT,
+				GPTModels:     []string{"gpt4"},
+				MaxUploadSize: 5 * 1024 * 1024,
+				MaxFileSize:   3 * 1024 * 1024,
 			},
 		},
 		{
 			name: "valid qwen with own url",
 			cfg: Config{
-				DBDsn:      "dsn",
-				Engine:     EngineQwen,
-				QwenUrl:    "http://qwen",
-				QwenKey:    "qk",
-				QwenModels: []string{"qm"},
+				DBDsn:         "dsn",
+				Engine:        EngineQwen,
+				QwenUrl:       "http://qwen",
+				QwenKey:       "qk",
+				QwenModels:    []string{"qm"},
+				MaxUploadSize: 5 * 1024 * 1024,
+				MaxFileSize:   3 * 1024 * 1024,
 			},
 		},
 		{
@@ -394,5 +400,108 @@ func TestLoadFromEnv_AllowFeedbackLog_One(t *testing.T) {
 
 	if !cfg.AllowFeedbackLog {
 		t.Error("expected AllowFeedbackLog true when VOICE_ALLOW_FEEDBACK=1")
+	}
+}
+
+func TestLoadFromEnv_MaxUploadSize_Default(t *testing.T) {
+	os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if cfg.MaxUploadSize != 5*1024*1024 {
+		t.Errorf("expected max upload size 5MB, got %d", cfg.MaxUploadSize)
+	}
+}
+
+func TestLoadFromEnv_MaxUploadSize_FromEnv(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_MAX_UPLOAD_SIZE", "10485760")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if cfg.MaxUploadSize != 10485760 {
+		t.Errorf("expected max upload size 10485760, got %d", cfg.MaxUploadSize)
+	}
+}
+
+func TestLoadFromEnv_MaxUploadSize_ZeroFallsBackToDefault(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_MAX_UPLOAD_SIZE", "0")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if cfg.MaxUploadSize != 5*1024*1024 {
+		t.Errorf("expected default 5MB when VOICE_MAX_UPLOAD_SIZE=0, got %d", cfg.MaxUploadSize)
+	}
+}
+
+func TestLoadFromEnv_MaxUploadSize_NegativeFallsBackToDefault(t *testing.T) {
+	os.Clearenv()
+	os.Setenv("VOICE_MAX_UPLOAD_SIZE", "-100")
+	defer os.Clearenv()
+
+	cfg := LoadFromEnv(nil)
+
+	if cfg.MaxUploadSize != 5*1024*1024 {
+		t.Errorf("expected default 5MB when VOICE_MAX_UPLOAD_SIZE=-100, got %d", cfg.MaxUploadSize)
+	}
+}
+
+func TestValidate_MaxUploadSizeZero(t *testing.T) {
+	cfg := Config{
+		DBDsn:         "dsn",
+		LiteLLMUrl:    "http://url",
+		LiteLLMKey:    "key",
+		Engine:        EngineGemini,
+		Models:        []string{"m1"},
+		MaxUploadSize: 0,
+		MaxFileSize:   3 * 1024 * 1024,
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("expected error when MaxUploadSize is 0")
+	}
+	if err != nil && err.Error() != "VOICE_MAX_UPLOAD_SIZE must be positive" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_MaxFileSizeOneLessThanMaxUploadSize(t *testing.T) {
+	cfg := Config{
+		DBDsn:         "dsn",
+		LiteLLMUrl:    "http://url",
+		LiteLLMKey:    "key",
+		Engine:        EngineGemini,
+		Models:        []string{"m1"},
+		MaxUploadSize: 5 * 1024 * 1024,
+		MaxFileSize:   5*1024*1024 - 1,
+	}
+
+	err := cfg.Validate()
+	if err != nil {
+		t.Errorf("expected no error when MaxFileSize == MaxUploadSize-1, got: %v", err)
+	}
+}
+
+func TestValidate_MaxFileSizeExceedsMaxUploadSize(t *testing.T) {
+	cfg := Config{
+		DBDsn:        "dsn",
+		LiteLLMUrl:   "http://url",
+		LiteLLMKey:   "key",
+		Engine:       EngineGemini,
+		Models:       []string{"m1"},
+		MaxUploadSize: 5 * 1024 * 1024,
+		MaxFileSize:   5 * 1024 * 1024,
+	}
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Error("expected error when MaxFileSize >= MaxUploadSize")
+	}
+	if err != nil && err.Error() != "VOICE_MAX_FILE_SIZE must be smaller than VOICE_MAX_UPLOAD_SIZE" {
+		t.Errorf("unexpected error: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

Replace hardcoded 5MB `maxUploadSize` constant with configurable `Config.MaxUploadSize` field.

Closes #9

## Changes

### `internal/config/config.go`
- Add `MaxUploadSize int64` field with comment explaining relationship to `MaxFileSize`
- Add `defaultMaxUploadSize = 5 * 1024 * 1024` constant
- Load from `VOICE_MAX_UPLOAD_SIZE` env var in `LoadFromEnv()`
- Add validation in `Validate()`:
  - `MaxUploadSize <= 0` → error
  - `MaxFileSize >= MaxUploadSize` → error

### `internal/api/transcribe.go`
- Remove `const maxUploadSize = 5 * 1024 * 1024`
- Use `h.cfg.MaxUploadSize` in `http.MaxBytesReader`

### Tests
- `config_test.go`: default value, env var override, zero/negative fallback, validation edge cases
- `api_test.go`: 413 response for oversized body + positive path for within-limit body

## Test Results

```
ok  github.com/Mininglamp-OSS/octo-speech/internal/api
ok  github.com/Mininglamp-OSS/octo-speech/internal/config
```

All existing + new tests pass.