### PR TITLE
feat: voice feedback opt-in compliance

### DIFF
--- a/cmd/speech/main.go
+++ b/cmd/speech/main.go
@@ -27,7 +27,10 @@ func main() {
 	logger, _ := zap.NewProduction()
 	defer logger.Sync()
 
-	cfg := config.LoadFromEnv(logger)
+	cfg, err := config.LoadFromEnv(logger)
+	if err != nil {
+		logger.Fatal("failed to load configuration", zap.Error(err))
+	}
 	if err := cfg.Validate(); err != nil {
 		logger.Fatal("invalid configuration", zap.Error(err))
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -93,7 +94,7 @@ type Config struct {
 	IdleTimeout  time.Duration
 }
 
-func LoadFromEnv(logger *zap.Logger) *Config {
+func LoadFromEnv(logger *zap.Logger) (*Config, error) {
 	models := make([]string, len(defaultModels))
 	copy(models, defaultModels)
 	gptModels := make([]string, len(defaultGPTModels))
@@ -129,7 +130,7 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 
 		ASRLogBufferSize:    defaultLogBufSize,
 		ASRLogRetentionDays: defaultRetention,
-		AllowFeedbackLog:    true,
+		AllowFeedbackLog:    false,
 
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 60 * time.Second,
@@ -280,9 +281,11 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 	cfg.FeedbackURL = os.Getenv("VOICE_FEEDBACK_URL")
 
 	if v := os.Getenv("VOICE_ALLOW_FEEDBACK"); v != "" {
-		if b, err := strconv.ParseBool(v); err == nil {
-			cfg.AllowFeedbackLog = b
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("invalid VOICE_ALLOW_FEEDBACK value %q: %w", v, err)
 		}
+		cfg.AllowFeedbackLog = b
 	}
 
 	if v := os.Getenv("ASR_LOG_BUFFER_SIZE"); v != "" {
@@ -313,7 +316,7 @@ func LoadFromEnv(logger *zap.Logger) *Config {
 		}
 	}
 
-	return cfg
+	return cfg, nil
 }
 
 func (c *Config) Validate() error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,7 +8,10 @@ import (
 func TestLoadFromEnv_Defaults(t *testing.T) {
 	os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.Port != 8780 {
 		t.Errorf("expected port 8780, got %d", cfg.Port)
@@ -61,8 +64,8 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	if len(cfg.Models) != 3 || cfg.Models[0] != "gemini-3.1-pro-preview" {
 		t.Errorf("unexpected default models: %v", cfg.Models)
 	}
-	if !cfg.AllowFeedbackLog {
-		t.Error("expected AllowFeedbackLog true by default")
+	if cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog false by default")
 	}
 }
 
@@ -84,7 +87,10 @@ func TestLoadFromEnv_CustomValues(t *testing.T) {
 
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.Port != 9090 {
 		t.Errorf("expected port 9090, got %d", cfg.Port)
@@ -122,7 +128,10 @@ func TestLoadFromEnv_CustomValues(t *testing.T) {
 func TestLoadFromEnv_FeedbackURL_Default(t *testing.T) {
 	os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.FeedbackURL != "" {
 		t.Errorf("expected empty feedback URL by default, got %q", cfg.FeedbackURL)
@@ -134,7 +143,10 @@ func TestLoadFromEnv_FeedbackURL_Set(t *testing.T) {
 	os.Setenv("VOICE_FEEDBACK_URL", "https://example.com/feedback")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.FeedbackURL != "https://example.com/feedback" {
 		t.Errorf("expected feedback URL 'https://example.com/feedback', got %q", cfg.FeedbackURL)
@@ -147,7 +159,10 @@ func TestLoadFromEnv_GPTForceAppend(t *testing.T) {
 	os.Setenv("VOICE_EDIT_MODE", "edit")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.EditMode != "append" {
 		t.Errorf("expected GPT to force append, got %s", cfg.EditMode)
 	}
@@ -158,7 +173,10 @@ func TestLoadFromEnv_GPTDefaultAppend(t *testing.T) {
 	os.Setenv("VOICE_ENGINE", "gpt")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if cfg.EditMode != "append" {
 		t.Errorf("expected GPT default append, got %s", cfg.EditMode)
 	}
@@ -336,10 +354,13 @@ func TestEngineShort(t *testing.T) {
 func TestLoadFromEnv_AllowFeedbackLog_Default(t *testing.T) {
 	os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if !cfg.AllowFeedbackLog {
-		t.Error("expected AllowFeedbackLog true by default")
+	if cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog false by default")
 	}
 }
 
@@ -348,7 +369,10 @@ func TestLoadFromEnv_AllowFeedbackLog_SetFalse(t *testing.T) {
 	os.Setenv("VOICE_ALLOW_FEEDBACK", "false")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.AllowFeedbackLog {
 		t.Error("expected AllowFeedbackLog false when VOICE_ALLOW_FEEDBACK=false")
@@ -360,22 +384,24 @@ func TestLoadFromEnv_AllowFeedbackLog_SetTrue(t *testing.T) {
 	os.Setenv("VOICE_ALLOW_FEEDBACK", "true")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !cfg.AllowFeedbackLog {
 		t.Error("expected AllowFeedbackLog true when VOICE_ALLOW_FEEDBACK=true")
 	}
 }
 
-func TestLoadFromEnv_AllowFeedbackLog_InvalidIgnored(t *testing.T) {
+func TestLoadFromEnv_AllowFeedbackLog_InvalidReturnsError(t *testing.T) {
 	os.Clearenv()
 	os.Setenv("VOICE_ALLOW_FEEDBACK", "yes")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
-
-	if !cfg.AllowFeedbackLog {
-		t.Error("expected AllowFeedbackLog to remain true when VOICE_ALLOW_FEEDBACK has invalid value")
+	_, err := LoadFromEnv(nil)
+	if err == nil {
+		t.Error("expected error when VOICE_ALLOW_FEEDBACK has invalid value")
 	}
 }
 
@@ -384,7 +410,10 @@ func TestLoadFromEnv_AllowFeedbackLog_Zero(t *testing.T) {
 	os.Setenv("VOICE_ALLOW_FEEDBACK", "0")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.AllowFeedbackLog {
 		t.Error("expected AllowFeedbackLog false when VOICE_ALLOW_FEEDBACK=0")
@@ -396,17 +425,36 @@ func TestLoadFromEnv_AllowFeedbackLog_One(t *testing.T) {
 	os.Setenv("VOICE_ALLOW_FEEDBACK", "1")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if !cfg.AllowFeedbackLog {
 		t.Error("expected AllowFeedbackLog true when VOICE_ALLOW_FEEDBACK=1")
 	}
 }
 
+func TestLoadFromEnv_AllowFeedbackLog_Unset(t *testing.T) {
+	os.Clearenv()
+
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.AllowFeedbackLog {
+		t.Error("expected AllowFeedbackLog false when VOICE_ALLOW_FEEDBACK is not set")
+	}
+}
+
 func TestLoadFromEnv_MaxUploadSize_Default(t *testing.T) {
 	os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.MaxUploadSize != 5*1024*1024 {
 		t.Errorf("expected max upload size 5MB, got %d", cfg.MaxUploadSize)
@@ -418,7 +466,10 @@ func TestLoadFromEnv_MaxUploadSize_FromEnv(t *testing.T) {
 	os.Setenv("VOICE_MAX_UPLOAD_SIZE", "10485760")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.MaxUploadSize != 10485760 {
 		t.Errorf("expected max upload size 10485760, got %d", cfg.MaxUploadSize)
@@ -430,7 +481,10 @@ func TestLoadFromEnv_MaxUploadSize_ZeroFallsBackToDefault(t *testing.T) {
 	os.Setenv("VOICE_MAX_UPLOAD_SIZE", "0")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.MaxUploadSize != 5*1024*1024 {
 		t.Errorf("expected default 5MB when VOICE_MAX_UPLOAD_SIZE=0, got %d", cfg.MaxUploadSize)
@@ -442,7 +496,10 @@ func TestLoadFromEnv_MaxUploadSize_NegativeFallsBackToDefault(t *testing.T) {
 	os.Setenv("VOICE_MAX_UPLOAD_SIZE", "-100")
 	defer os.Clearenv()
 
-	cfg := LoadFromEnv(nil)
+	cfg, err := LoadFromEnv(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	if cfg.MaxUploadSize != 5*1024*1024 {
 		t.Errorf("expected default 5MB when VOICE_MAX_UPLOAD_SIZE=-100, got %d", cfg.MaxUploadSize)


### PR DESCRIPTION
## Changes

- Change `AllowFeedbackLog` default from `true` to `false` (opt-in compliance: feedback logging disabled unless user explicitly enables)
- `LoadFromEnv` now returns error on invalid `VOICE_ALLOW_FEEDBACK` value (fail-fast, no silent fallback for privacy flags)
- `cmd/speech/main.go` updated to handle load error (Fatal on misconfiguration)
- Tests updated to cover new default and fail-fast behavior

## Behavior Change

- **Before:** Feedback logging enabled by default; invalid env values silently ignored
- **After:** Feedback logging disabled by default; invalid env values cause startup failure

Deployments that rely on feedback logging must explicitly set `VOICE_ALLOW_FEEDBACK=true`.

## Fallback Chain

`allow_feedback` request param → `VOICE_ALLOW_FEEDBACK` env → default `false`

## Related

Part of the voice feedback opt-in compliance work across octo-speech / octo-server / octo-web.