### PR TITLE
feat(local-config): per-user local ASR config CRUD + partial update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ Thumbs.db
 
 /admin
 speech
+octo-speech-bin
+Dockerfile.local

--- a/cmd/speech/main.go
+++ b/cmd/speech/main.go
@@ -82,6 +82,7 @@ func main() {
 	transcribeHandler := api.NewTranscribeHandler(svc, cfg, asrLogger, logger)
 	configHandler := api.NewConfigHandler(cfg, localCfgStore)
 	vocabHandler := api.NewVocabularyHandler(vocabStore)
+	localConfigHandler := api.NewLocalConfigHandler(localCfgStore)
 
 	auth := api.AuthMiddleware(appStore)
 
@@ -93,6 +94,9 @@ func main() {
 		protected.PUT("/vocabularies", vocabHandler.Put)
 		protected.GET("/vocabularies", vocabHandler.Get)
 		protected.DELETE("/vocabularies", vocabHandler.Delete)
+		protected.PUT("/local-config", localConfigHandler.Put)
+		protected.GET("/local-config", localConfigHandler.Get)
+		protected.DELETE("/local-config", localConfigHandler.Delete)
 	}
 
 	addr := fmt.Sprintf(":%d", cfg.Port)

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Mininglamp-OSS/octo-speech
 go 1.25.0
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-sql-driver/mysql v1.8.1
 	github.com/golang-jwt/jwt/v5 v5.3.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc0=
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
@@ -38,6 +40,7 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.7 h1:ZWSB3igEs+d0qvnxR/ZBzXVmxkgt8DdzP6m9pfuVLDM=
 github.com/klauspost/cpuid/v2 v2.2.7/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/gin-gonic/gin"
 
 	"github.com/Mininglamp-OSS/octo-speech/internal/asrlog"
@@ -1269,5 +1270,512 @@ func TestTranscribeHandler_MaxUploadSize(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	if resp["msg"] != "request body too large" {
 		t.Errorf("unexpected msg: %v", resp["msg"])
+	}
+}
+
+func setupLocalConfigRouter() (*gin.Engine, *LocalConfigHandler) {
+	cfg := &config.Config{
+		LocalEnabled:       false,
+		LocalTimeoutMs:     10000,
+		LocalProbeURL:      "http://localhost:8787/",
+		LocalTranscribeURL: "http://localhost:8787/v1/voice/transcribe",
+	}
+	localStore := store.NewLocalConfigStore(nil, cfg)
+	h := NewLocalConfigHandler(localStore)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.PUT("/v1/speech/local-config", h.Put)
+	r.GET("/v1/speech/local-config", h.Get)
+	r.DELETE("/v1/speech/local-config", h.Delete)
+	return r, h
+}
+
+func setupLocalConfigRouterWithMock(t *testing.T) (*gin.Engine, sqlmock.Sqlmock) {
+	t.Helper()
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Close() })
+
+	cfg := &config.Config{
+		LocalEnabled:       false,
+		LocalTimeoutMs:     10000,
+		LocalProbeURL:      "http://localhost:8787/",
+		LocalTranscribeURL: "http://localhost:8787/v1/voice/transcribe",
+	}
+	localStore := store.NewLocalConfigStore(db, cfg)
+	h := NewLocalConfigHandler(localStore)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "test-app")
+		c.Next()
+	})
+	r.PUT("/v1/speech/local-config", h.Put)
+	r.GET("/v1/speech/local-config", h.Get)
+	r.DELETE("/v1/speech/local-config", h.Delete)
+	return r, mock
+}
+
+func TestLocalConfigHandler_PutValidation(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	tests := []struct {
+		name string
+		body string
+		want int
+		msg  string
+	}{
+		{
+			"invalid json",
+			`{bad`,
+			400,
+			"invalid request body",
+		},
+		{
+			"missing subject_id",
+			`{"scope_type":"global","scope_id":"default","enabled":true}`,
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing scope_type",
+			`{"subject_id":"user1","scope_id":"default","enabled":true}`,
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing scope_id",
+			`{"subject_id":"user1","scope_type":"global","enabled":true}`,
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"invalid scope_type",
+			`{"subject_id":"user1","scope_type":"invalid","scope_id":"default","enabled":true}`,
+			400,
+			"invalid scope_type, expected: global, space, org, project",
+		},
+		{
+			"missing enabled",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","timeout_ms":5000}`,
+			400,
+			"enabled is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("PUT", "/v1/speech/local-config",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+
+			var resp map[string]interface{}
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["msg"] != tt.msg {
+				t.Errorf("expected msg %q, got %v", tt.msg, resp["msg"])
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_GetValidation(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	tests := []struct {
+		name string
+		url  string
+		want int
+		msg  string
+	}{
+		{
+			"missing all params",
+			"/v1/speech/local-config",
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing scope_type",
+			"/v1/speech/local-config?subject_id=u1&scope_id=s1",
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing scope_id",
+			"/v1/speech/local-config?subject_id=u1&scope_type=global",
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"invalid scope_type",
+			"/v1/speech/local-config?subject_id=u1&scope_type=bad&scope_id=s1",
+			400,
+			"invalid scope_type, expected: global, space, org, project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", tt.url, nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+
+			var resp map[string]interface{}
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["msg"] != tt.msg {
+				t.Errorf("expected msg %q, got %v", tt.msg, resp["msg"])
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_GetDefaultValues(t *testing.T) {
+	cfg := &config.Config{
+		LocalEnabled:       false,
+		LocalTimeoutMs:     10000,
+		LocalProbeURL:      "http://localhost:8787/",
+		LocalTranscribeURL: "http://localhost:8787/v1/voice/transcribe",
+	}
+	localStore := store.NewLocalConfigStore(nil, cfg)
+	h := NewLocalConfigHandler(localStore)
+
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("app_id", "")
+		c.Next()
+	})
+	r.GET("/v1/speech/local-config", h.Get)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v1/speech/local-config?subject_id=u1&scope_type=global&scope_id=default", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+
+	if resp["enabled"] != false {
+		t.Errorf("expected enabled false, got %v", resp["enabled"])
+	}
+	if resp["timeout_ms"] != float64(10000) {
+		t.Errorf("expected timeout_ms 10000, got %v", resp["timeout_ms"])
+	}
+	if resp["probe_url"] != "http://localhost:8787/" {
+		t.Errorf("expected default probe_url, got %v", resp["probe_url"])
+	}
+	if resp["transcribe_url"] != "http://localhost:8787/v1/voice/transcribe" {
+		t.Errorf("expected default transcribe_url, got %v", resp["transcribe_url"])
+	}
+}
+
+func TestLocalConfigHandler_DeleteValidation(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	tests := []struct {
+		name string
+		url  string
+		want int
+		msg  string
+	}{
+		{
+			"missing all params",
+			"/v1/speech/local-config",
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing subject_id",
+			"/v1/speech/local-config?scope_type=global&scope_id=default",
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"invalid scope_type",
+			"/v1/speech/local-config?subject_id=u1&scope_type=bad&scope_id=s1",
+			400,
+			"invalid scope_type, expected: global, space, org, project",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("DELETE", tt.url, nil)
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+
+			var resp map[string]interface{}
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["msg"] != tt.msg {
+				t.Errorf("expected msg %q, got %v", tt.msg, resp["msg"])
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_PatchPartialUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			"only timeout_ms without enabled",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","timeout_ms":5000}`,
+			400,
+		},
+		{
+			"only enabled",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true}`,
+			200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r *gin.Engine
+			if tt.want == 200 {
+				var mock sqlmock.Sqlmock
+				r, mock = setupLocalConfigRouterWithMock(t)
+				mock.ExpectExec("INSERT INTO local_asr_config").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+			} else {
+				r, _ = setupLocalConfigRouter()
+			}
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("PUT", "/v1/speech/local-config",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_PatchEnabledRequired(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	body := `{"subject_id":"user1","scope_type":"global","scope_id":"default","timeout_ms":5000}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/v1/speech/local-config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "enabled is required" {
+		t.Errorf("expected msg 'enabled is required', got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_TimeoutMsValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			"timeout_ms=0",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"timeout_ms":0}`,
+			400,
+		},
+		{
+			"timeout_ms=-5",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"timeout_ms":-5}`,
+			400,
+		},
+		{
+			"timeout_ms=60001",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"timeout_ms":60001}`,
+			400,
+		},
+		{
+			"timeout_ms=30000",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"timeout_ms":30000}`,
+			200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r *gin.Engine
+			if tt.want == 200 {
+				var mock sqlmock.Sqlmock
+				r, mock = setupLocalConfigRouterWithMock(t)
+				mock.ExpectExec("INSERT INTO local_asr_config").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+			} else {
+				r, _ = setupLocalConfigRouter()
+			}
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("PUT", "/v1/speech/local-config",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_URLValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want int
+	}{
+		{
+			"probe_url not-a-url",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"probe_url":"not-a-url"}`,
+			400,
+		},
+		{
+			"probe_url ftp scheme",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"probe_url":"ftp://x"}`,
+			400,
+		},
+		{
+			"probe_url valid http",
+			`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"probe_url":"http://localhost:8787/"}`,
+			200,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var r *gin.Engine
+			if tt.want == 200 {
+				var mock sqlmock.Sqlmock
+				r, mock = setupLocalConfigRouterWithMock(t)
+				mock.ExpectExec("INSERT INTO local_asr_config").
+					WillReturnResult(sqlmock.NewResult(1, 1))
+			} else {
+				r, _ = setupLocalConfigRouter()
+			}
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("PUT", "/v1/speech/local-config",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_GetQueryError(t *testing.T) {
+	r, mock := setupLocalConfigRouterWithMock(t)
+
+	mock.ExpectQuery("SELECT enabled, timeout_ms, probe_url, transcribe_url").
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/v1/speech/local-config?subject_id=u1&scope_type=global&scope_id=default", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "failed to query local config" {
+		t.Errorf("expected msg 'failed to query local config', got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_DeleteNotFound(t *testing.T) {
+	r, mock := setupLocalConfigRouterWithMock(t)
+
+	mock.ExpectExec("DELETE FROM local_asr_config").
+		WithArgs("test-app", "u1", "global", "default").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/v1/speech/local-config?subject_id=u1&scope_type=global&scope_id=default", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "config not found" {
+		t.Errorf("expected msg 'config not found', got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_DeleteSuccess(t *testing.T) {
+	r, mock := setupLocalConfigRouterWithMock(t)
+
+	mock.ExpectExec("DELETE FROM local_asr_config").
+		WithArgs("test-app", "u1", "global", "default").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/v1/speech/local-config?subject_id=u1&scope_type=global&scope_id=default", nil)
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestLocalConfigHandler_URLTooLong(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	longURL := "http://example.com/" + strings.Repeat("a", 500)
+	body := fmt.Sprintf(`{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":true,"probe_url":"%s"}`, longURL)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/v1/speech/local-config", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	msg, _ := resp["msg"].(string)
+	if !strings.Contains(msg, "500 characters") {
+		t.Errorf("expected error about 500 characters, got %v", resp["msg"])
 	}
 }

--- a/internal/api/config.go
+++ b/internal/api/config.go
@@ -28,7 +28,11 @@ func (h *ConfigHandler) Handle(c *gin.Context) {
 		appID, _ = v.(string)
 	}
 
-	localCfg := h.localCfgStore.Query(appID, subjectID, scopeType, scopeID)
+	localCfg, err := h.localCfgStore.Query(appID, subjectID, scopeType, scopeID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "failed to query local config"})
+		return
+	}
 
 	resp := gin.H{
 		"enabled":              true,

--- a/internal/api/local_config.go
+++ b/internal/api/local_config.go
@@ -1,0 +1,163 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/Mininglamp-OSS/octo-speech/internal/store"
+)
+
+type LocalConfigHandler struct {
+	localCfgStore *store.LocalConfigStore
+}
+
+func NewLocalConfigHandler(localCfgStore *store.LocalConfigStore) *LocalConfigHandler {
+	return &LocalConfigHandler{localCfgStore: localCfgStore}
+}
+
+func (h *LocalConfigHandler) Put(c *gin.Context) {
+	appID, _ := c.Get("app_id")
+	appIDStr, _ := appID.(string)
+
+	var req struct {
+		SubjectID     string  `json:"subject_id"`
+		ScopeType     string  `json:"scope_type"`
+		ScopeID       string  `json:"scope_id"`
+		Enabled       *bool   `json:"enabled"`
+		TimeoutMs     *int    `json:"timeout_ms"`
+		ProbeURL      *string `json:"probe_url"`
+		TranscribeURL *string `json:"transcribe_url"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid request body"})
+		return
+	}
+
+	if req.SubjectID == "" || req.ScopeType == "" || req.ScopeID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "subject_id, scope_type, and scope_id are required"})
+		return
+	}
+
+	if !store.IsValidScopeType(req.ScopeType) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid scope_type, expected: global, space, org, project"})
+		return
+	}
+
+	if req.Enabled == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "enabled is required"})
+		return
+	}
+
+	if req.TimeoutMs != nil {
+		if *req.TimeoutMs < 1 || *req.TimeoutMs > 60000 {
+			c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "timeout_ms must be between 1 and 60000"})
+			return
+		}
+	}
+
+	if req.ProbeURL != nil {
+		if err := validateLocalURL(*req.ProbeURL); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "probe_url: " + err.Error()})
+			return
+		}
+	}
+
+	if req.TranscribeURL != nil {
+		if err := validateLocalURL(*req.TranscribeURL); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "transcribe_url: " + err.Error()})
+			return
+		}
+	}
+
+	if err := h.localCfgStore.Upsert(appIDStr, req.SubjectID, req.ScopeType, req.ScopeID, *req.Enabled, req.TimeoutMs, req.ProbeURL, req.TranscribeURL); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "failed to save local config"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
+}
+
+func (h *LocalConfigHandler) Get(c *gin.Context) {
+	appID, _ := c.Get("app_id")
+	appIDStr, _ := appID.(string)
+
+	subjectID := c.Query("subject_id")
+	scopeType := c.Query("scope_type")
+	scopeID := c.Query("scope_id")
+
+	if subjectID == "" || scopeType == "" || scopeID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "subject_id, scope_type, and scope_id are required"})
+		return
+	}
+
+	if !store.IsValidScopeType(scopeType) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid scope_type, expected: global, space, org, project"})
+		return
+	}
+
+	localCfg, err := h.localCfgStore.Query(appIDStr, subjectID, scopeType, scopeID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "failed to query local config"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"status":         http.StatusOK,
+		"enabled":        localCfg.Enabled,
+		"timeout_ms":     localCfg.TimeoutMs,
+		"probe_url":      localCfg.ProbeURL,
+		"transcribe_url": localCfg.TranscribeURL,
+	})
+}
+
+func (h *LocalConfigHandler) Delete(c *gin.Context) {
+	appID, _ := c.Get("app_id")
+	appIDStr, _ := appID.(string)
+
+	subjectID := c.Query("subject_id")
+	scopeType := c.Query("scope_type")
+	scopeID := c.Query("scope_id")
+
+	if subjectID == "" || scopeType == "" || scopeID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "subject_id, scope_type, and scope_id are required"})
+		return
+	}
+
+	if !store.IsValidScopeType(scopeType) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid scope_type, expected: global, space, org, project"})
+		return
+	}
+
+	rows, err := h.localCfgStore.Delete(appIDStr, subjectID, scopeType, scopeID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "failed to delete local config"})
+		return
+	}
+	if rows == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"status": http.StatusNotFound, "msg": "config not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
+}
+
+func validateLocalURL(raw string) error {
+	if len(raw) > 500 {
+		return fmt.Errorf("URL must not exceed 500 characters")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("invalid URL")
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("scheme must be http or https")
+	}
+	if u.Host == "" {
+		return fmt.Errorf("host is required")
+	}
+	return nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -118,7 +118,7 @@ func LoadFromEnv(logger *zap.Logger) (*Config, error) {
 		QwenModels:   qwenModels,
 
 		EmotionEmoji:       true,
-		LocalEnabled:       true,
+		LocalEnabled:       false,
 		LocalTimeoutMs:     10000,
 		LocalProbeURL:      "http://localhost:8787/",
 		LocalTranscribeURL: "http://localhost:8787/v1/voice/transcribe",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,8 +37,8 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	if !cfg.EmotionEmoji {
 		t.Error("expected emotion emoji true")
 	}
-	if !cfg.LocalEnabled {
-		t.Error("expected local enabled true")
+	if cfg.LocalEnabled {
+		t.Error("expected local enabled false")
 	}
 	if cfg.LocalTimeoutMs != 10000 {
 		t.Errorf("expected local timeout 10000, got %d", cfg.LocalTimeoutMs)

--- a/internal/migration/migrations/006_local_asr_config_default_disabled.sql
+++ b/internal/migration/migrations/006_local_asr_config_default_disabled.sql
@@ -1,0 +1,5 @@
+-- +migrate Up
+ALTER TABLE `local_asr_config` ALTER COLUMN `enabled` SET DEFAULT 0;
+
+-- +migrate Down
+ALTER TABLE `local_asr_config` ALTER COLUMN `enabled` SET DEFAULT 1;

--- a/internal/store/local_config.go
+++ b/internal/store/local_config.go
@@ -2,9 +2,13 @@ package store
 
 import (
 	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
 
 	"github.com/Mininglamp-OSS/octo-speech/internal/config"
 )
+
 
 type LocalASRConfig struct {
 	Enabled       bool
@@ -22,7 +26,56 @@ func NewLocalConfigStore(db *sql.DB, cfg *config.Config) *LocalConfigStore {
 	return &LocalConfigStore{db: db, cfg: cfg}
 }
 
-func (s *LocalConfigStore) Query(appID, subjectID, scopeType, scopeID string) *LocalASRConfig {
+func (s *LocalConfigStore) Upsert(appID, subjectID, scopeType, scopeID string, enabled bool, timeoutMs *int, probeURL, transcribeURL *string) error {
+	cols := []string{"app_id", "subject_id", "scope_type", "scope_id", "enabled"}
+	args := []interface{}{appID, subjectID, scopeType, scopeID, enabled}
+	updates := []string{"enabled=VALUES(enabled)"}
+
+	if timeoutMs != nil {
+		cols = append(cols, "timeout_ms")
+		args = append(args, *timeoutMs)
+		updates = append(updates, "timeout_ms=VALUES(timeout_ms)")
+	}
+	if probeURL != nil {
+		cols = append(cols, "probe_url")
+		args = append(args, *probeURL)
+		updates = append(updates, "probe_url=VALUES(probe_url)")
+	}
+	if transcribeURL != nil {
+		cols = append(cols, "transcribe_url")
+		args = append(args, *transcribeURL)
+		updates = append(updates, "transcribe_url=VALUES(transcribe_url)")
+	}
+
+	placeholders := make([]string, len(cols))
+	for i := range placeholders {
+		placeholders[i] = "?"
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO local_asr_config (%s) VALUES (%s) ON DUPLICATE KEY UPDATE %s",
+		strings.Join(cols, ", "),
+		strings.Join(placeholders, ", "),
+		strings.Join(updates, ", "),
+	)
+
+	_, err := s.db.Exec(query, args...)
+	return err
+}
+
+func (s *LocalConfigStore) Delete(appID, subjectID, scopeType, scopeID string) (int64, error) {
+	res, err := s.db.Exec(
+		`DELETE FROM local_asr_config
+		 WHERE app_id = ? AND subject_id = ? AND scope_type = ? AND scope_id = ?`,
+		appID, subjectID, scopeType, scopeID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+func (s *LocalConfigStore) Query(appID, subjectID, scopeType, scopeID string) (*LocalASRConfig, error) {
 	result := &LocalASRConfig{
 		Enabled:       s.cfg.LocalEnabled,
 		TimeoutMs:     s.cfg.LocalTimeoutMs,
@@ -31,7 +84,7 @@ func (s *LocalConfigStore) Query(appID, subjectID, scopeType, scopeID string) *L
 	}
 
 	if appID == "" || subjectID == "" || scopeType == "" || scopeID == "" {
-		return result
+		return result, nil
 	}
 
 	var enabled sql.NullInt64
@@ -47,7 +100,10 @@ func (s *LocalConfigStore) Query(appID, subjectID, scopeType, scopeID string) *L
 	).Scan(&enabled, &timeoutMs, &probeURL, &transcribeURL)
 
 	if err != nil {
-		return result
+		if errors.Is(err, sql.ErrNoRows) {
+			return result, nil
+		}
+		return nil, fmt.Errorf("query local config: %w", err)
 	}
 
 	if enabled.Valid {
@@ -63,5 +119,5 @@ func (s *LocalConfigStore) Query(appID, subjectID, scopeType, scopeID string) *L
 		result.TranscribeURL = transcribeURL.String
 	}
 
-	return result
+	return result, nil
 }

--- a/internal/store/local_config_test.go
+++ b/internal/store/local_config_test.go
@@ -1,0 +1,143 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestUpsert_AllFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := &LocalConfigStore{db: db}
+
+	timeout := 3000
+	probe := "http://probe"
+	transcribe := "http://transcribe"
+
+	mock.ExpectExec(
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url\)`+
+			` VALUES \(\?, \?, \?, \?, \?, \?, \?, \?\)`+
+			` ON DUPLICATE KEY UPDATE enabled=VALUES\(enabled\), timeout_ms=VALUES\(timeout_ms\), probe_url=VALUES\(probe_url\), transcribe_url=VALUES\(transcribe_url\)`,
+	).WithArgs("app1", "sub1", "org", "scope1", true, 3000, "http://probe", "http://transcribe").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = s.Upsert("app1", "sub1", "org", "scope1", true, &timeout, &probe, &transcribe)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestUpsert_EnabledOnly_NoOptionalFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := &LocalConfigStore{db: db}
+
+	mock.ExpectExec(
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled\)`+
+			` VALUES \(\?, \?, \?, \?, \?\)`+
+			` ON DUPLICATE KEY UPDATE enabled=VALUES\(enabled\)$`,
+	).WithArgs("app1", "sub1", "org", "scope1", false).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = s.Upsert("app1", "sub1", "org", "scope1", false, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestUpsert_PartialFields(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := &LocalConfigStore{db: db}
+
+	timeout := 5000
+
+	mock.ExpectExec(
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled, timeout_ms\)`+
+			` VALUES \(\?, \?, \?, \?, \?, \?\)`+
+			` ON DUPLICATE KEY UPDATE enabled=VALUES\(enabled\), timeout_ms=VALUES\(timeout_ms\)$`,
+	).WithArgs("app1", "sub1", "org", "scope1", true, 5000).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = s.Upsert("app1", "sub1", "org", "scope1", true, &timeout, nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestDelete_RowsAffected(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := &LocalConfigStore{db: db}
+
+	mock.ExpectExec(`DELETE FROM local_asr_config`).
+		WithArgs("app1", "sub1", "org", "scope1").
+		WillReturnResult(sqlmock.NewResult(0, 1))
+
+	rows, err := s.Delete("app1", "sub1", "org", "scope1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("expected 1 row affected, got %d", rows)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestDelete_NoRows(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	s := &LocalConfigStore{db: db}
+
+	mock.ExpectExec(`DELETE FROM local_asr_config`).
+		WithArgs("app1", "sub1", "org", "scope1").
+		WillReturnResult(sqlmock.NewResult(0, 0))
+
+	rows, err := s.Delete("app1", "sub1", "org", "scope1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rows != 0 {
+		t.Errorf("expected 0 rows affected, got %d", rows)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -88,18 +88,20 @@ func TestIsValidScopeType(t *testing.T) {
 
 func TestLocalConfigStore_Query_DefaultValues(t *testing.T) {
 	cfg := &config.Config{
-		LocalEnabled:       true,
+		LocalEnabled:       false,
 		LocalTimeoutMs:     10000,
 		LocalProbeURL:      "http://localhost:8787/",
 		LocalTranscribeURL: "http://localhost:8787/v1/voice/transcribe",
 	}
 
-	// nil db is fine since we're testing the no-db-hit path
 	s := NewLocalConfigStore(nil, cfg)
-	result := s.Query("", "", "", "")
+	result, err := s.Query("", "", "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-	if !result.Enabled {
-		t.Error("expected enabled true")
+	if result.Enabled {
+		t.Error("expected enabled false")
 	}
 	if result.TimeoutMs != 10000 {
 		t.Errorf("expected timeout 10000, got %d", result.TimeoutMs)


### PR DESCRIPTION
## Summary

Per-user local ASR configuration CRUD with partial-update semantics.

Closes #23

## Changes

- `PATCH /v1/speech/local-config`: Create or update per-user local ASR config
- `GET /v1/speech/local-config`: Read config (returns defaults if no record exists — by design)
- `DELETE /v1/speech/local-config`: Remove config (returns 404 if not found)
- `internal/store/local_config.go`: Upsert with partial-update, Delete with RowsAffected
- Migrations: 003 (table creation) + 006 (ALTER enabled DEFAULT 0)

## Partial Update Semantics

- `enabled`: **REQUIRED** on every PATCH request (400 if omitted). Always persisted explicitly — no implicit defaults, no read-modify-write race.
- `timeout_ms`, `probe_url`, `transcribe_url`: optional — only updated when present in request body (nil fields are NOT overwritten).

## Design Decisions

### GET returns 200 with defaults for missing rows (intentional)

When no per-user config exists, GET returns HTTP 200 with the effective config (process-level defaults from env vars). This is **by design** — the client needs to know the effective config regardless of whether a DB record exists. The `/v1/speech/config` endpoint has the same behavior.

### Trust model: API key = trusted backend (re: IDOR concern)

Authentication is via app-level API key (Bearer token), not end-user session token. The API key represents a **trusted backend service** that manages configs on behalf of its users. `subject_id` authorization is the caller's responsibility — same pattern as the existing vocabulary API. This API is never directly exposed to end-users.

### Input validation

- `timeout_ms`: [1, 60000]
- `probe_url` / `transcribe_url`: must be http(s) scheme, non-empty host, max 500 chars
- `scope_type`: must be one of `space`, `org`, `global`

### MySQL compatibility

Uses `INSERT ... ON DUPLICATE KEY UPDATE col=VALUES(col)` syntax (MySQL 5.7+ compatible), consistent with existing store code (`vocabulary.go`).
