### PR TITLE
feat: add POST /local-config/reset endpoint

### DIFF
--- a/cmd/speech/main.go
+++ b/cmd/speech/main.go
@@ -97,6 +97,7 @@ func main() {
 		protected.PUT("/local-config", localConfigHandler.Put)
 		protected.GET("/local-config", localConfigHandler.Get)
 		protected.DELETE("/local-config", localConfigHandler.Delete)
+		protected.POST("/local-config/reset", localConfigHandler.Reset)
 	}
 
 	addr := fmt.Sprintf(":%d", cfg.Port)

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1291,6 +1291,7 @@ func setupLocalConfigRouter() (*gin.Engine, *LocalConfigHandler) {
 	r.PUT("/v1/speech/local-config", h.Put)
 	r.GET("/v1/speech/local-config", h.Get)
 	r.DELETE("/v1/speech/local-config", h.Delete)
+	r.POST("/v1/speech/local-config/reset", h.Reset)
 	return r, h
 }
 
@@ -1319,6 +1320,7 @@ func setupLocalConfigRouterWithMock(t *testing.T) (*gin.Engine, sqlmock.Sqlmock)
 	r.PUT("/v1/speech/local-config", h.Put)
 	r.GET("/v1/speech/local-config", h.Get)
 	r.DELETE("/v1/speech/local-config", h.Delete)
+	r.POST("/v1/speech/local-config/reset", h.Reset)
 	return r, mock
 }
 
@@ -1777,5 +1779,142 @@ func TestLocalConfigHandler_URLTooLong(t *testing.T) {
 	msg, _ := resp["msg"].(string)
 	if !strings.Contains(msg, "500 characters") {
 		t.Errorf("expected error about 500 characters, got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_ResetMissingFields(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	tests := []struct {
+		name string
+		body string
+		want int
+		msg  string
+	}{
+		{
+			"missing subject_id",
+			`{"scope_type":"global","scope_id":"default","enabled":true}`,
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing scope_type",
+			`{"subject_id":"user1","scope_id":"default","enabled":true}`,
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+		{
+			"missing scope_id",
+			`{"subject_id":"user1","scope_type":"global","enabled":true}`,
+			400,
+			"subject_id, scope_type, and scope_id are required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("POST", "/v1/speech/local-config/reset",
+				strings.NewReader(tt.body))
+			req.Header.Set("Content-Type", "application/json")
+			r.ServeHTTP(w, req)
+
+			if w.Code != tt.want {
+				t.Errorf("expected %d, got %d: %s", tt.want, w.Code, w.Body.String())
+			}
+
+			var resp map[string]interface{}
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			if resp["msg"] != tt.msg {
+				t.Errorf("expected msg %q, got %v", tt.msg, resp["msg"])
+			}
+		})
+	}
+}
+
+func TestLocalConfigHandler_ResetMissingEnabled(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	body := `{"subject_id":"user1","scope_type":"global","scope_id":"default"}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/local-config/reset", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "enabled is required" {
+		t.Errorf("expected msg 'enabled is required', got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_ResetInvalidScopeType(t *testing.T) {
+	r, _ := setupLocalConfigRouter()
+
+	body := `{"subject_id":"user1","scope_type":"invalid","scope_id":"default","enabled":true}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/local-config/reset", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "invalid scope_type, expected: global, space, org, project" {
+		t.Errorf("expected invalid scope_type msg, got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_ResetSuccess(t *testing.T) {
+	r, mock := setupLocalConfigRouterWithMock(t)
+
+	mock.ExpectExec("INSERT INTO local_asr_config").
+		WithArgs("test-app", "user1", "space", "space1", true, 10000, "http://localhost:8787/", "http://localhost:8787/v1/voice/transcribe").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	body := `{"subject_id":"user1","scope_type":"space","scope_id":"space1","enabled":true}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/local-config/reset", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "ok" {
+		t.Errorf("expected msg 'ok', got %v", resp["msg"])
+	}
+}
+
+func TestLocalConfigHandler_ResetDBError(t *testing.T) {
+	r, mock := setupLocalConfigRouterWithMock(t)
+
+	mock.ExpectExec("INSERT INTO local_asr_config").
+		WillReturnError(fmt.Errorf("connection refused"))
+
+	body := `{"subject_id":"user1","scope_type":"global","scope_id":"default","enabled":false}`
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/v1/speech/local-config/reset", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["msg"] != "failed to reset local config" {
+		t.Errorf("expected msg 'failed to reset local config', got %v", resp["msg"])
 	}
 }

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1876,7 +1876,7 @@ func TestLocalConfigHandler_ResetSuccess(t *testing.T) {
 	r, mock := setupLocalConfigRouterWithMock(t)
 
 	mock.ExpectExec("INSERT INTO local_asr_config").
-		WithArgs("test-app", "user1", "space", "space1", true, 10000, "http://localhost:8787/", "http://localhost:8787/v1/voice/transcribe").
+		WithArgs("test-app", "user1", "space", "space1", true).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	body := `{"subject_id":"user1","scope_type":"space","scope_id":"space1","enabled":true}`
@@ -1891,8 +1891,17 @@ func TestLocalConfigHandler_ResetSuccess(t *testing.T) {
 
 	var resp map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	if resp["msg"] != "ok" {
-		t.Errorf("expected msg 'ok', got %v", resp["msg"])
+	if resp["enabled"] != true {
+		t.Errorf("expected enabled true, got %v", resp["enabled"])
+	}
+	if resp["timeout_ms"] != float64(10000) {
+		t.Errorf("expected timeout_ms 10000, got %v", resp["timeout_ms"])
+	}
+	if resp["probe_url"] != "http://localhost:8787/" {
+		t.Errorf("expected default probe_url, got %v", resp["probe_url"])
+	}
+	if resp["transcribe_url"] != "http://localhost:8787/v1/voice/transcribe" {
+		t.Errorf("expected default transcribe_url, got %v", resp["transcribe_url"])
 	}
 }
 

--- a/internal/api/local_config.go
+++ b/internal/api/local_config.go
@@ -150,7 +150,13 @@ func (h *LocalConfigHandler) Reset(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
+	c.JSON(http.StatusOK, gin.H{
+		"status":         http.StatusOK,
+		"enabled":        *req.Enabled,
+		"timeout_ms":     h.localCfgStore.GetDefaultTimeoutMs(),
+		"probe_url":      h.localCfgStore.GetDefaultProbeURL(),
+		"transcribe_url": h.localCfgStore.GetDefaultTranscribeURL(),
+	})
 }
 
 func (h *LocalConfigHandler) Delete(c *gin.Context) {

--- a/internal/api/local_config.go
+++ b/internal/api/local_config.go
@@ -114,6 +114,45 @@ func (h *LocalConfigHandler) Get(c *gin.Context) {
 	})
 }
 
+func (h *LocalConfigHandler) Reset(c *gin.Context) {
+	appID, _ := c.Get("app_id")
+	appIDStr, _ := appID.(string)
+
+	var req struct {
+		SubjectID string `json:"subject_id"`
+		ScopeType string `json:"scope_type"`
+		ScopeID   string `json:"scope_id"`
+		Enabled   *bool  `json:"enabled"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid request body"})
+		return
+	}
+
+	if req.SubjectID == "" || req.ScopeType == "" || req.ScopeID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "subject_id, scope_type, and scope_id are required"})
+		return
+	}
+
+	if !store.IsValidScopeType(req.ScopeType) {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "invalid scope_type, expected: global, space, org, project"})
+		return
+	}
+
+	if req.Enabled == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"status": http.StatusBadRequest, "msg": "enabled is required"})
+		return
+	}
+
+	if err := h.localCfgStore.ResetToDefault(appIDStr, req.SubjectID, req.ScopeType, req.ScopeID, *req.Enabled); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"status": http.StatusInternalServerError, "msg": "failed to reset local config"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": http.StatusOK, "msg": "ok"})
+}
+
 func (h *LocalConfigHandler) Delete(c *gin.Context) {
 	appID, _ := c.Get("app_id")
 	appIDStr, _ := appID.(string)

--- a/internal/store/local_config.go
+++ b/internal/store/local_config.go
@@ -63,6 +63,25 @@ func (s *LocalConfigStore) Upsert(appID, subjectID, scopeType, scopeID string, e
 	return err
 }
 
+// ResetToDefault performs an UPSERT that sets enabled to the given value
+// and forces timeout_ms, probe_url, transcribe_url to system defaults.
+func (s *LocalConfigStore) ResetToDefault(appID, subjectID, scopeType, scopeID string, enabled bool) error {
+	defaultTimeout := s.cfg.LocalTimeoutMs
+	defaultProbe := s.cfg.LocalProbeURL
+	defaultTranscribe := s.cfg.LocalTranscribeURL
+
+	query := `INSERT INTO local_asr_config (app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+              ON DUPLICATE KEY UPDATE
+                enabled=VALUES(enabled),
+                timeout_ms=VALUES(timeout_ms),
+                probe_url=VALUES(probe_url),
+                transcribe_url=VALUES(transcribe_url)`
+
+	_, err := s.db.Exec(query, appID, subjectID, scopeType, scopeID, enabled, defaultTimeout, defaultProbe, defaultTranscribe)
+	return err
+}
+
 func (s *LocalConfigStore) Delete(appID, subjectID, scopeType, scopeID string) (int64, error) {
 	res, err := s.db.Exec(
 		`DELETE FROM local_asr_config

--- a/internal/store/local_config.go
+++ b/internal/store/local_config.go
@@ -64,22 +64,30 @@ func (s *LocalConfigStore) Upsert(appID, subjectID, scopeType, scopeID string, e
 }
 
 // ResetToDefault performs an UPSERT that sets enabled to the given value
-// and forces timeout_ms, probe_url, transcribe_url to system defaults.
+// and NULLs timeout_ms, probe_url, transcribe_url so Query() falls back to server defaults.
 func (s *LocalConfigStore) ResetToDefault(appID, subjectID, scopeType, scopeID string, enabled bool) error {
-	defaultTimeout := s.cfg.LocalTimeoutMs
-	defaultProbe := s.cfg.LocalProbeURL
-	defaultTranscribe := s.cfg.LocalTranscribeURL
-
-	query := `INSERT INTO local_asr_config (app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url)
-              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+	query := `INSERT INTO local_asr_config (app_id, subject_id, scope_type, scope_id, enabled)
+              VALUES (?, ?, ?, ?, ?)
               ON DUPLICATE KEY UPDATE
                 enabled=VALUES(enabled),
-                timeout_ms=VALUES(timeout_ms),
-                probe_url=VALUES(probe_url),
-                transcribe_url=VALUES(transcribe_url)`
+                timeout_ms=NULL,
+                probe_url=NULL,
+                transcribe_url=NULL`
 
-	_, err := s.db.Exec(query, appID, subjectID, scopeType, scopeID, enabled, defaultTimeout, defaultProbe, defaultTranscribe)
+	_, err := s.db.Exec(query, appID, subjectID, scopeType, scopeID, enabled)
 	return err
+}
+
+func (s *LocalConfigStore) GetDefaultTimeoutMs() int {
+	return s.cfg.LocalTimeoutMs
+}
+
+func (s *LocalConfigStore) GetDefaultProbeURL() string {
+	return s.cfg.LocalProbeURL
+}
+
+func (s *LocalConfigStore) GetDefaultTranscribeURL() string {
+	return s.cfg.LocalTranscribeURL
 }
 
 func (s *LocalConfigStore) Delete(appID, subjectID, scopeType, scopeID string) (int64, error) {

--- a/internal/store/local_config_test.go
+++ b/internal/store/local_config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+
+	"github.com/Mininglamp-OSS/octo-speech/internal/config"
 )
 
 func TestUpsert_AllFields(t *testing.T) {
@@ -135,6 +137,76 @@ func TestDelete_NoRows(t *testing.T) {
 	}
 	if rows != 0 {
 		t.Errorf("expected 0 rows affected, got %d", rows)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestResetToDefault_EnabledTrue(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	cfg := &config.Config{
+		LocalTimeoutMs:     10000,
+		LocalProbeURL:      "http://localhost:8787/",
+		LocalTranscribeURL: "http://localhost:8787/v1/voice/transcribe",
+	}
+	s := NewLocalConfigStore(db, cfg)
+
+	mock.ExpectExec(
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url\)`+
+			` VALUES \(\?, \?, \?, \?, \?, \?, \?, \?\)`+
+			` ON DUPLICATE KEY UPDATE`+
+			`\s+enabled=VALUES\(enabled\),`+
+			`\s+timeout_ms=VALUES\(timeout_ms\),`+
+			`\s+probe_url=VALUES\(probe_url\),`+
+			`\s+transcribe_url=VALUES\(transcribe_url\)`,
+	).WithArgs("app1", "sub1", "space", "scope1", true, 10000, "http://localhost:8787/", "http://localhost:8787/v1/voice/transcribe").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = s.ResetToDefault("app1", "sub1", "space", "scope1", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unmet expectations: %v", err)
+	}
+}
+
+func TestResetToDefault_EnabledFalse(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	cfg := &config.Config{
+		LocalTimeoutMs:     5000,
+		LocalProbeURL:      "http://example.com/probe",
+		LocalTranscribeURL: "http://example.com/transcribe",
+	}
+	s := NewLocalConfigStore(db, cfg)
+
+	mock.ExpectExec(
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url\)`+
+			` VALUES \(\?, \?, \?, \?, \?, \?, \?, \?\)`+
+			` ON DUPLICATE KEY UPDATE`+
+			`\s+enabled=VALUES\(enabled\),`+
+			`\s+timeout_ms=VALUES\(timeout_ms\),`+
+			`\s+probe_url=VALUES\(probe_url\),`+
+			`\s+transcribe_url=VALUES\(transcribe_url\)`,
+	).WithArgs("app1", "sub1", "org", "scope1", false, 5000, "http://example.com/probe", "http://example.com/transcribe").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	err = s.ResetToDefault("app1", "sub1", "org", "scope1", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/internal/store/local_config_test.go
+++ b/internal/store/local_config_test.go
@@ -159,14 +159,14 @@ func TestResetToDefault_EnabledTrue(t *testing.T) {
 	s := NewLocalConfigStore(db, cfg)
 
 	mock.ExpectExec(
-		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url\)`+
-			` VALUES \(\?, \?, \?, \?, \?, \?, \?, \?\)`+
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled\)`+
+			` VALUES \(\?, \?, \?, \?, \?\)`+
 			` ON DUPLICATE KEY UPDATE`+
 			`\s+enabled=VALUES\(enabled\),`+
-			`\s+timeout_ms=VALUES\(timeout_ms\),`+
-			`\s+probe_url=VALUES\(probe_url\),`+
-			`\s+transcribe_url=VALUES\(transcribe_url\)`,
-	).WithArgs("app1", "sub1", "space", "scope1", true, 10000, "http://localhost:8787/", "http://localhost:8787/v1/voice/transcribe").
+			`\s+timeout_ms=NULL,`+
+			`\s+probe_url=NULL,`+
+			`\s+transcribe_url=NULL`,
+	).WithArgs("app1", "sub1", "space", "scope1", true).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = s.ResetToDefault("app1", "sub1", "space", "scope1", true)
@@ -194,14 +194,14 @@ func TestResetToDefault_EnabledFalse(t *testing.T) {
 	s := NewLocalConfigStore(db, cfg)
 
 	mock.ExpectExec(
-		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled, timeout_ms, probe_url, transcribe_url\)`+
-			` VALUES \(\?, \?, \?, \?, \?, \?, \?, \?\)`+
+		`INSERT INTO local_asr_config \(app_id, subject_id, scope_type, scope_id, enabled\)`+
+			` VALUES \(\?, \?, \?, \?, \?\)`+
 			` ON DUPLICATE KEY UPDATE`+
 			`\s+enabled=VALUES\(enabled\),`+
-			`\s+timeout_ms=VALUES\(timeout_ms\),`+
-			`\s+probe_url=VALUES\(probe_url\),`+
-			`\s+transcribe_url=VALUES\(transcribe_url\)`,
-	).WithArgs("app1", "sub1", "org", "scope1", false, 5000, "http://example.com/probe", "http://example.com/transcribe").
+			`\s+timeout_ms=NULL,`+
+			`\s+probe_url=NULL,`+
+			`\s+transcribe_url=NULL`,
+	).WithArgs("app1", "sub1", "org", "scope1", false).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	err = s.ResetToDefault("app1", "sub1", "org", "scope1", false)


### PR DESCRIPTION
Add a reset endpoint that restores local ASR config fields to server defaults while explicitly setting the enabled state.

## Endpoint

`POST /local-config/reset`

### Request body (all fields required)

```json
{
  "subject_id": "user1",
  "scope_type": "space",
  "scope_id": "space1",
  "enabled": true
}
```

- `enabled` is **required** — the caller explicitly specifies the desired enabled state
- The endpoint resets `timeout_ms`, `probe_url`, and `transcribe_url` by setting them to NULL in the database, so `Query()` dynamically falls back to current server defaults

### Response (same shape as GET)

```json
{
  "status": 200,
  "enabled": true,
  "timeout_ms": 10000,
  "probe_url": "http://localhost:8787/",
  "transcribe_url": "http://localhost:8787/v1/voice/transcribe"
}
```

## Design

- **Reset ≠ Delete**: Reset preserves the row and sets enabled, but NULLs the override fields so they track server defaults. Delete removes the row entirely.
- **Dynamic fallback**: Because overrides are NULL after reset, any future changes to server defaults are automatically picked up — no stale snapshots.
- `DELETE /local-config` is kept for backward compatibility.