### PR TITLE
fix: restrict review-feed to ready_for_review and review_requested

### DIFF
--- a/.github/workflows/octo-pr-review-feed.yml
+++ b/.github/workflows/octo-pr-review-feed.yml
@@ -2,7 +2,7 @@ name: Octo PR Review Feed
 
 on:
   pull_request_target:
-    types: [opened, ready_for_review, review_requested, synchronize]
+    types: [ready_for_review, review_requested]
 
 permissions: {}
 


### PR DESCRIPTION
Restrict octo-pr-review-feed event types.