### PR TITLE
ci: add -shuffle=on to go test for order-dependency detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,7 +125,7 @@ jobs:
           while read -r pkg; do
             mysql -h 127.0.0.1 -uroot -pdemo -e "DROP DATABASE IF EXISTS test; CREATE DATABASE test CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;"
             echo "::group::go test $pkg"
-            if ! go test -race -count=1 -timeout 5m "$pkg"; then
+            if ! go test -race -shuffle=on -count=1 -timeout 5m "$pkg"; then
               fail=1
             fi
             echo "::endgroup::"


### PR DESCRIPTION
## What

Add `-shuffle=on` flag to all `go test` invocations in CI.

## Why

`-shuffle=on` randomizes test execution order, exposing implicit ordering dependencies that cause flaky tests. This is a zero-cost quality improvement — any test that fails with shuffle enabled has a latent bug.

## Changes

Added `-shuffle=on` to `go test` commands in `.github/workflows/ci.yml`.

## Risk

None. If tests fail after this change, it reveals pre-existing hidden ordering dependencies that should be fixed.