### PR TITLE
ci: pin .github reusable workflows to @v1

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -11,6 +11,6 @@ permissions: {}
 
 jobs:
   add-to-project:
-    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/auto-add-to-project.yml@v1
     secrets:
       PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -40,7 +40,7 @@ permissions: {}
 
 jobs:
   check-sprint:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@v1
     with:
       pr-number: ${{ github.event.pull_request.number }}
       repo-name: ${{ github.repository }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ concurrency:
 jobs:
   analyze:
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-codeql.yml@v1
     with:
       language: go
     permissions:

--- a/.github/workflows/docker-lint.yml
+++ b/.github/workflows/docker-lint.yml
@@ -18,5 +18,5 @@ on:
 
 jobs:
   docker-lint:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-docker-lint.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-docker-lint.yml@v1
     # Ref: Mininglamp-OSS workflow optimization T11

--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -23,4 +23,4 @@ permissions:
 
 jobs:
   history:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml@v1

--- a/.github/workflows/issue-welcome.yml
+++ b/.github/workflows/issue-welcome.yml
@@ -8,4 +8,4 @@ jobs:
   welcome:
     permissions:
       issues: write
-    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/issue-welcome.yml@v1

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@ permissions: {}
 
 jobs:
   label:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-labeler.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-labeler.yml@v1
     with:
       pr_number: ${{ github.event.pull_request.number }}
       repo_owner: ${{ github.repository_owner }}

--- a/.github/workflows/octo-ci-status.yml
+++ b/.github/workflows/octo-ci-status.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-ci-status.yml@v1
     with:
       repo_name: ${{ github.event.workflow_run.repository.name }}
       workflow_name: ${{ github.event.workflow_run.name }}

--- a/.github/workflows/octo-issue-feed.yml
+++ b/.github/workflows/octo-issue-feed.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   notify:
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-issue-notify.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       issue_number: ${{ github.event.issue.number }}

--- a/.github/workflows/octo-pr-result-notify.yml
+++ b/.github/workflows/octo-pr-result-notify.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   pr-result:
     if: github.event_name == 'pull_request_target'
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-result-notify.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-result-notify.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}
@@ -31,7 +31,7 @@ jobs:
       github.event_name == 'pull_request_review' &&
       (github.event.review.state == 'approved' || github.event.review.state == 'changes_requested') &&
       github.event.pull_request.head.repo.full_name == github.repository
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-result-notify.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-result-notify.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/octo-pr-review-feed.yml
+++ b/.github/workflows/octo-pr-review-feed.yml
@@ -9,7 +9,7 @@ permissions: {}
 jobs:
   notify:
     if: ${{ !github.event.pull_request.draft }}
-    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-review-feed.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/octo-pr-review-feed.yml@v1
     with:
       repo_name: ${{ github.event.repository.name }}
       pr_number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-contributor-welcome.yml
+++ b/.github/workflows/pr-contributor-welcome.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   welcome:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-pr-contributor-welcome.yml@v1
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   draft:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-drafter.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-drafter.yml@v1
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -21,7 +21,7 @@ permissions: {}
 
 jobs:
   publish:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-publish.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-release-publish.yml@v1
     with:
       tag: ${{ inputs.tag }}
       validate_run_id: ${{ inputs.validate_run_id }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   stale:
-    uses: Mininglamp-OSS/.github/.github/workflows/reusable-stale.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-stale.yml@v1
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/workflow-sanity.yml
+++ b/.github/workflows/workflow-sanity.yml
@@ -14,6 +14,6 @@ permissions: {}
 
 jobs:
   sanity:
-    uses: Mininglamp-OSS/.github/.github/workflows/workflow-sanity.yml@main
+    uses: Mininglamp-OSS/.github/.github/workflows/workflow-sanity.yml@v1
     permissions:
       contents: read


### PR DESCRIPTION
Migrate caller refs `@main` -> rolling `@v1` now that Mininglamp-OSS/.github has governed versioning (v1.0.0 + rolling v1). Issue notification caller repointed to `octo-issue-notify.yml@v1` (renamed from octo-issue-feed.yml). Files changed: 16.