### PR TITLE
test: use low-entropy placeholders for fake secrets in admin tests

### DIFF
--- a/internal/admin/handler_test.go
+++ b/internal/admin/handler_test.go
@@ -353,7 +353,7 @@ func TestCSRFMiddleware_ConstantTimeCompare(t *testing.T) {
 		c.String(200, "ok")
 	})
 
-	token := "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4"
+	token := "test-csrf-token-placeholder-0000"
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/test", nil)

--- a/internal/admin/keygen_test.go
+++ b/internal/admin/keygen_test.go
@@ -75,7 +75,7 @@ func TestGenerateAppID_Base62Chars(t *testing.T) {
 }
 
 func TestHashAPIKey(t *testing.T) {
-	key := "sk-xK9mB2nR4pL7qW1sAbCdEfGhIjKlM"
+	key := "sk-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 	hash := hashAPIKey(key)
 
 	if len(hash) != 64 {


### PR DESCRIPTION
## Summary

The `secret-scan` (gitleaks) CI job currently fails on **every** open PR, independent of the PR's actual changes. Two hardcoded fake credentials in test files are matched by gitleaks' `generic-api-key` rule (entropy above threshold), producing `leaks found: 2` and exit code 1.

Flagged locations:
- `internal/admin/keygen_test.go:78` — `TestHashAPIKey` input key
- `internal/admin/handler_test.go:356` — `TestCSRFMiddleware_ConstantTimeCompare` token

Both are dummy test fixtures, not real secrets. This PR replaces them with obvious low-entropy placeholder strings so gitleaks no longer flags them, while keeping test semantics identical.

## Why not a gitleaks allowlist?
An allowlist file would also work, but changing the fixture values keeps the fix local to the tests, avoids introducing repo-wide scanner config, and removes the noisy findings at the source.

## Verification
- `go build ./...` — OK
- `go vet ./...` — OK
- `gofmt` — clean
- `go test ./internal/admin/...` — pass
- Local `gitleaks 8.30.1` (same version as CI) scan of the working tree: **no leaks found**

Test intent preserved:
- `TestHashAPIKey` only checks SHA-256 hex length, determinism, and that a different input yields a different hash; the new placeholder differs from the other literal, so all assertions still hold.
- `TestCSRFMiddleware_ConstantTimeCompare` compares the token against itself (match, 200) and against `token+"x"` (mismatch, 403); the value content is irrelevant.

No production code changed.